### PR TITLE
rules: fix typo (elastic/humio)

### DIFF
--- a/rules/templates/rules/base.html
+++ b/rules/templates/rules/base.html
@@ -88,11 +88,13 @@
 					</div>
                     <div class="panel-body">
                     <div id="suri-status" class="label label-default"><a href="/{{ generator }}/">Suricata</a></div>
-{% if es_backend == "HUMIO" %}
+{% if elasticsearch %}
+    {% if es_backend == "HUMIO" %}
                     <div id="health" class="label label-default"><a href="{% url 'humio' %}">Humio</a></div>
-{% endif %}
-{% if elasticsearch and es_backend == "elasticsearch" %}
+    {% endif %}
+    {% if es_backend == "ELASTICSEARCH" %}
                     <div id="health" class="label label-default"><a href="{% url 'elasticsearch' %}">Elasticsearch</a></div>
+    {% endif %}
 {% endif %}
                     <div id="disk-status" class="label label-default"><a href="{% url monitoring_url %}">Disk</a></div>
                     <div id="memory-status" class="label label-default"><a href="{% url monitoring_url %}">Memory</a></div>


### PR DESCRIPTION
Fix typo "elasticsearch" => "ELASTICSEARCH" and make sure humio status is
only displayed when elasticsearch is enabled but es_backend is "HUMIO".